### PR TITLE
Simplify notification setup for test results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,26 @@
-# Ignore Pipenv virtual environment
+# Ignore virtual environment
 /.venv
+# If using pipenv and want to exclude the virtualenvs created outside the project
+# *.lock
 
 # Ignore Robot Framework output files
 /output.xml
 /log.html
 /report.html
+/pabot_results/
 
-# Ignore any compiled Python files
+# Ignore Python bytecode and cache
 *.pyc
+__pycache__/
 
-# Ignore any local configuration files
-/.vscode
-/.idea
-/.vs
-/.Reports
+# Ignore local configuration files and directories
+.vscode/
+.idea/
+.vs/
+Reports/
+
+# Additional common ignores
+.DS_Store
+*.log
+.env
+docker-compose.override.yml

--- a/Library/EmailNotificationLibrary.py
+++ b/Library/EmailNotificationLibrary.py
@@ -1,0 +1,43 @@
+import smtplib
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+
+class EmailNotificationLibrary:
+    def __init__(self, config_file="../config/config.txt"):  # Ensure this path is correct
+        self.config = self.read_config(config_file)
+        self.smtp_server = self.config['SMTP Server']
+        self.port = int(self.config['Port'])
+        self.username = self.config['Login']
+        self.password = self.config['SMTP Key']
+        self.recipient = self.config['Recipient']
+
+    @staticmethod
+    def read_config(config_file):
+        config = {}
+        with open(config_file, 'r') as file:
+            for line in file:
+                if line.strip():
+                    key, value = line.strip().split(':', 1)
+                    config[key] = value.strip()
+        return config
+
+    def send_test_status_email(self, test_name, status):
+        subject = f"Test Result for: {test_name}"
+        body = f"The test '{test_name}' has completed with status: {status}."
+        self.send_email(subject, body)
+
+    def send_email(self, subject, body):
+        message = MIMEMultipart()
+        message['From'] = self.username
+        message['To'] = self.recipient
+        message['Subject'] = subject
+        message.attach(MIMEText(body, 'plain'))
+        try:
+            server = smtplib.SMTP(self.smtp_server, self.port)
+            server.starttls()
+            server.login(self.username, self.password)
+            server.sendmail(self.username, self.recipient, message.as_string())
+            server.quit()
+        except Exception as e:
+            print(f"Failed to send email: {e}")

--- a/Resources/Settings.resource
+++ b/Resources/Settings.resource
@@ -5,7 +5,7 @@ Library           SeleniumLibrary
 Library           Browser
 Library           ../Library/csv_reader.py
 Library           ../Library/ShopistKeywords.py
-
+Library           ../Library/EmailNotificationLibrary.py
 
 Resource    Variables.resource
 Resource    eCommerce_keywords.resource

--- a/Resources/eCommerce_keywords.resource
+++ b/Resources/eCommerce_keywords.resource
@@ -1,7 +1,11 @@
-*** Settings ***
-Library    CSVLibrary
-
 *** Keywords ***
+
+Send Test Email On Completion
+    [Arguments]    ${TEST_NAME}
+    ${status}=    Get Variable Value    ${TEST STATUS}    FAILED
+    Send Test Status Email    ${TEST_NAME}    ${status}
+
+
 Read CSV File
     [Arguments]    ${file_path}
     ${data}=    Read CSV    ${file_path}

--- a/Tests/eCommerce_tests.robot
+++ b/Tests/eCommerce_tests.robot
@@ -4,9 +4,11 @@ Resource    ../Resources/Settings.resource
 *** Test Cases ***
 Update Profile Name
     [Documentation]    Test updating profile name on shopist.io
+    [Teardown]    Send Test Email On Completion    Update Profile Name
     Update Profile Name
 
 Scrape Shopist Sofas
     [Documentation]    Scrape sofa names and prices on shopist.io
+    [Teardown]    Send Test Email On Completion    Scrape Shopist Sofas
     Scrape Shopist Sofas    ${URL}    ${OUTPUT_FILE}
     ShopistKeywords.Close Browser

--- a/config/config.ini
+++ b/config/config.ini
@@ -1,0 +1,5 @@
+SMTP Server: smtp.example.com
+Port: 587
+Login: your_email@example.com
+SMTP Key: your_smtp_password
+Recipient: recipient_email@example.com

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,10 @@
 # ECommerce Robot Tests
 
-This project contains automated tests for an eCommerce website using Robot Framework.
+This project contains automated tests for an eCommerce website using Robot Framework, with integrated email notifications for test results.
 
 ## Overview
 
-The automated tests are designed to perform various actions on the [shopist.io](https://shopist.io/) eCommerce website. These tests cover scenarios such as updating profile information and scraping sofa names and prices.
+The automated tests are designed to perform various actions on the [shopist.io](https://shopist.io/) eCommerce website, covering scenarios such as updating profile information and scraping sofa names and prices. After each test case execution, an email notification is sent with the test result.
 
 ## Dependencies
 
@@ -21,9 +21,25 @@ The automated tests are designed to perform various actions on the [shopist.io](
    pipenv install
    ```
 
+## Configuration
+
+Before running the tests, configure the SMTP settings and recipient email address for sending notifications:
+
+1. Edit the `config.txt` file located in the `config` directory.
+2. Specify your SMTP server, port, login, SMTP key, and recipient email address.
+
+Example `config.txt`:
+```
+SMTP Server: smtp.example.com
+Port: 587
+Login: your_email@example.com
+SMTP Key: your_smtp_password
+Recipient: recipient_email@example.com
+```
+
 ## Usage
 
-To run the tests, use the following command:
+To run the tests and receive email notifications upon completion, use the following command:
 ```
 pipenv run robot --outputdir Reports .\Tests\eCommerce_tests.robot
 ```
@@ -32,17 +48,19 @@ pipenv run robot --outputdir Reports .\Tests\eCommerce_tests.robot
 
 ### Update Profile Name
 
-This test case updates the profile name on the shopist.io website. It reads the first and last name from a CSV file located at `Data/names.csv`.
+This test case updates the profile name on the shopist.io website and sends an email notification with the test result.
 
 ### Scrape Shopist Sofas
 
-This test case scrapes the names and prices of sofas from the shopist.io website and saves the results to a CSV file.
+This test case scrapes the names and prices of sofas from the shopist.io website, saves the results to a CSV file, and sends an email notification with the test result.
 
 ## Structure
 
 - **Tests**: Contains the test cases written in Robot Framework.
 - **Resources**: Contains resource files including settings, variables, and keywords.
 - **Data**: Contains input data files such as CSV files.
+- **Library**: Contains the `EmailNotificationLibrary.py` for sending email notifications.
+- **config**: Contains the `config.txt` for email notification configuration.
 
 ## Author
 


### PR DESCRIPTION
- Create EmailNotificationLibrary.
- Create config.txt to include only one recipient field, simplifying the configuration process.
- Modify test cases to include a teardown step that sends an email notification with the test name and status, ensuring consistent communication for all test outcomes.
- Update documentation and README to reflect changes in the email notification configuration and usage.